### PR TITLE
Remove use of hard coded secrets

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -93,11 +93,11 @@ module.exports = function(app, passport) {
 
   // CookieParser should be above session
   app.use(cookieParser());
-  app.use(cookieSession({secret: 'secret'}));
+  app.use(cookieSession({secret: process.env['DEDOS_WEB_COOKIE_SECRET']}));
   app.use(session({
     resave: true,
     saveUninitialized: true,
-    secret: pkg.name,
+    secret: process.env['DEDOS_WEB_SESSION_SECRET'],
     cookie: {
       maxAge: 3600000
     },


### PR DESCRIPTION
**Description**
This pull request fixes a security issue by removing the hard coded cookie and session secrets. This change will instead make the application fetch them from the `DEDOS_WEB_COOKIE_SECRET` and `DEDOS_WEB_SESSION_SECRET` environment variables.

By using a hard coded secret, a would-be attacker could manipulate the cookie data and re-sign it using the same secret - potentially leading to an authentication bypass and privilege escalation.

**Vulnerability Classification**
CWE-259: Use of Hard-coded Password
CWE-302: Authentication Bypass by Assumed-Immutable Data

**CVE-ID**
[CVE-2018-10813](https://www.cvedetails.com/cve/CVE-2018-10813/)

**CVSS v3 Score**
6.5 (Medium)

**CVSS v3 Vector**
[AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N)
